### PR TITLE
Migrate Travis CI to container-based builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ python:
 install: "pip install -r requirements.txt"
 before_script: flake8 pynlpir
 script: make test
+sudo: false


### PR DESCRIPTION
This PR migrates PyNLPIR from using Travis CI's legacy infrastructure to the container-based infrastructure. See the following link for more details: https://docs.travis-ci.com/user/migrating-from-legacy

This addresses #48.