### PR TITLE
fixed issue #52

### DIFF
--- a/pynlpir/pos_map.py
+++ b/pynlpir/pos_map.py
@@ -157,7 +157,13 @@ def _get_pos_name(pos_code, names='parent', english=True, pos_map=POS_MAP):
         logger.debug("Found parent part of speech name '%s'. Descending to "
                      "look for child name for '%s'" % (pos_entry[1], pos_code))
         sub_pos = _get_pos_name(pos_code, names, english, sub_map)
-        pos = pos + sub_pos if names == 'all' else (sub_pos, )
+
+        if names == 'all':
+            # sub_pos can be None sometimes (e.g. for a word '甲')
+            pos = pos + sub_pos if sub_pos else pos
+        else:
+            pos = (sub_pos, )
+
     name = pos if names == 'all' else pos[-1]
     logger.debug("Part of speech name found: '%s'" % repr(name)
                  if isinstance(name, tuple) else name)

--- a/pynlpir/tests/test_init.py
+++ b/pynlpir/tests/test_init.py
@@ -101,6 +101,45 @@ class TestNLPIR(unittest.TestCase):
             self.fail('Segment function timed out.')
         self.assertEqual(expected_seg_s, seg_s)
 
+    def test_issue_52(self):
+        """
+        Tests for issue #52 -- segment(pos_names='all') fails for certain texts
+        input.
+        """
+        # it seems '甲' returns 'Mg', which is not listed in the POS_MAP.
+        # thus in this case 'None' needs to be returned for '甲'.
+        s = u'其中，新增了甲卡西酮、曲马多、安钠咖等12种新类型毒品的定罪量刑数量标准，' \
+            u'并下调了在我国危害较为严重的毒品氯胺酮的定罪量刑数量标准。'
+
+        segments = pynlpir.segment(s=s, pos_tagging=True, pos_names='all')
+
+        expected_segments = [
+            (u'其中', 'pronoun:demonstrative pronoun'),
+            (u'，', 'punctuation mark:comma'), (u'新增', 'verb'),
+            (u'了', 'particle:particle 了/喽'), (u'甲', 'numeral'),
+            (u'卡', 'noun'), (u'西', 'distinguishing word'), (u'酮', 'noun'),
+            (u'、', 'punctuation mark:enumeration comma'),
+            (u'曲马多', 'noun:personal name:transcribed personal name'),
+            (u'、', 'punctuation mark:enumeration comma'),
+            (u'安', 'noun:personal name:Chinese surname'), (u'钠', 'noun'),
+            (u'咖', 'noun'), (u'等', 'particle:particle 等/等等/云云'),
+            (u'12', 'numeral'), (u'种', 'classifier'), (u'新', 'adjective'),
+            (u'类型', 'noun'), (u'毒品', 'noun'),
+            (u'的', 'particle:particle 的/底'), (u'定罪', 'verb:noun-verb'),
+            (u'量刑', 'verb:noun-verb'), (u'数量', 'noun'), (u'标准', 'noun'),
+            (u'，', 'punctuation mark:comma'),
+            (u'并', 'conjunction:coordinating conjunction'), (u'下调', 'verb'),
+            (u'了', 'particle:particle 了/喽'), (u'在', 'preposition'),
+            (u'我国', 'noun'), (u'危害', 'verb:noun-verb'), (u'较为', 'adverb'),
+            (u'严重', 'adjective'), (u'的', 'particle:particle 的/底'),
+            (u'毒品', 'noun'), (u'氯', 'noun'), (u'胺', 'noun'), (u'酮', 'noun'),
+            (u'的', 'particle:particle 的/底'), (u'定罪', 'verb:noun-verb'),
+            (u'量刑', 'verb:noun-verb'), (u'数量', 'noun'), (u'标准', 'noun'),
+            (u'。', 'punctuation mark:period'),
+        ]
+
+        self.assertEqual(segments, expected_segments)
+
 
 class TestNLPIRInit(unittest.TestCase):
     """Unit tests for pynlpir initialization."""


### PR DESCRIPTION
Fixed the issue #52, which I created, and wrote a unittest.

It seems the root cause of the issues is NLPIR sometimes returns pos tags which are not defined in dict `pynlpir.pos_map.POS_MAP`. For example, NLPIR returns `Mg` for word '甲', which isn't defined in the `POS_MAP`. In this case `None` needs to be returned for the word, but instead it caused the error.

I simply added an IF statement which avoids adding `None` to a tuple.